### PR TITLE
Add explicit GitHub Actions token permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   bundle:
     name: Test


### PR DESCRIPTION
## Summary
- Add a top-level `permissions` block in `.github/workflows/test.yml`.
- Set `contents: read` as the minimal required `GITHUB_TOKEN` scope for this workflow.
- Keep workflow behavior unchanged while aligning with least-privilege guidance.

## Why
CodeQL flags this workflow for missing explicit token permissions. Defining minimal permissions reduces accidental token overreach and keeps security posture explicit.

## Validation
- Workflow YAML structure reviewed locally (`.github/workflows/test.yml`).