### PR TITLE
update with documentation to troubleshoot a scan below the threshold

### DIFF
--- a/.agents/skills/debug-snapshot-threshold/SKILL.md
+++ b/.agents/skills/debug-snapshot-threshold/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: debug-snapshot-threshold
+description: Diagnose smoke-test row-count alerts (e.g. "Row count below threshold" issues filed by RowCountTest) against the Site Scanning snapshot. Use when investigating a smoke-test failure that compares the published snapshot CSV to the target-url-list, or any user question of the form "why does the snapshot have N rows / why did the threshold trip / is the engine broken".
+---
+
+# Debug Snapshot Threshold Alerts
+
+Use this when a `RowCountTest` smoke test fires (typically as a GitHub issue titled "Row count below 95% threshold" in `GSA/site-scanning`) and you need to decide whether the engine is actually short or the smoke test is a false positive.
+
+## Background you must know
+
+- The "Expected rows" number in the issue body is `indexDf.count()` from `https://raw.githubusercontent.com/GSA/federal-website-index/main/data/site-scanning-target-url-list.csv`, parsed by `dataframe-js`. See `smoke_tests/src/services/tests/RowCountTest.ts:21-25` and `smoke_tests/src/services/tests/AllTests.ts:11`.
+- The "Snapshot rows" number is `snapshotDf.count()` from `https://api.gsa.gov/technology/site-scanning/data/site-scanning-latest.csv`, also parsed by `dataframe-js`.
+- The threshold is computed dynamically: `floor(indexCount * 0.95)` (`RowCountTest.ts:30`). Nothing is hardcoded.
+- `dataframe-js`'s CSV parser is fragile. The target-url-list has historically contained malformed rows (free-text like `... and ...`, `... to be ...`, `unclassifiedurl:https:\\...`) that pandas absorbs cleanly but dataframe-js mis-handles. **The first thing to suspect is parser mismatch, not engine failure.**
+
+## Workflow
+
+Don't speculate. Run the numbers.
+
+### 1. Pull the *real* counts with pandas
+
+The repo's own pandas reads are the ground truth (matches what every other report uses).
+
+```sh
+python3 -m pip install -q pandas  # if not already installed
+```
+
+```py
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context  # CI does this too
+import pandas as pd
+
+snap = pd.read_csv('https://api.gsa.gov/technology/site-scanning/data/site-scanning-latest.csv', low_memory=False)
+idx  = pd.read_csv('https://raw.githubusercontent.com/GSA/federal-website-index/main/data/site-scanning-target-url-list.csv')
+print('snapshot rows (pandas):', len(snap))
+print('index rows (pandas):   ', len(idx))
+print('gap:                   ', len(idx) - len(snap))
+print('95% threshold:         ', int(len(idx) * 0.95))
+```
+
+If the pandas snapshot count is >= 95% of the pandas index count, the engine is fine, and the smoke test is wrong (parser bug). Stop here, report findings, recommend closing the issue and fixing `RowCountTest.ts`.
+
+### 2. Confirm the engine ran
+
+```py
+print(snap['scan_date'].str[:10].value_counts().sort_index())
+print(snap['primary_scan_status'].value_counts(dropna=False).head(15))
+```
+
+- A normal run shows the bulk of rows on one recent day.
+- A mix of `completed` and recorded failures (`dns_resolution_error`, `timeout`, `connection_refused`, ...) is normal and means the engine *did* attempt those URLs. Failures still produce rows — they don't disappear from the snapshot.
+- If `scan_date` is stale or rows look truncated, escalate to the engine repo (`GSA/site-scanning-engine`).
+
+### 3. Identify the real missing URLs
+
+Run the existing generator. It does exactly the comparison you need.
+
+```sh
+python3 main.py generate-missing-target-url-report
+```
+
+Output: `reports/missing-target-url-in-snapshot.csv`. Stdout prints `Target URL Count`, `Snapshot URL Count`, `Missing URLs Count`.
+
+Categorize the missing entries:
+
+- **Malformed index rows** (literal spaces, `and`/`to be`, backslashes, `unclassifiedurl:` prefix). Not the engine's fault — bad data in `GSA/federal-website-index`.
+- **Internal / VPN-gated subdomains** (NIH/NLM `lforms-*`, `lhc-*`, LLNL `*.llnl.gov`, etc.). Engine can't reach them by design.
+- **Staging / UAT** (`*uat*`, `household-survey*`, etc.). Same.
+- **Actually-public unreachable** — these are the only ones worth flagging.
+
+### 4. Decide
+
+- pandas counts pass threshold → **smoke-test parser bug**. Close the issue. Recommend replacing `DataFrame.fromCSV` in `RowCountTest.ts` with a stricter parser (e.g. papaparse) and/or cleaning the upstream garbage rows.
+- pandas counts fail threshold and `scan_date` is recent → genuine engine shortfall. Escalate to `GSA/site-scanning-engine` with the missing-url categories.
+- pandas counts fail threshold and `scan_date` is stale → engine didn't run. Check engine's GitHub Actions.
+
+## Things not to do
+
+- Don't trust the numbers in the issue body. They come from `dataframe-js` and have been wrong before.
+- Don't assume "27k of 29k = engine outage". Failed scans still produce rows; the snapshot only shrinks if the engine never wrote them.
+- Don't edit `RowCountTest.ts` thresholds to silence alerts. The threshold isn't the bug; the parser is.
+- Don't hand-edit `reports/missing-target-url-in-snapshot.csv` — it's regenerated by CI.
+
+## Report template
+
+When reporting findings back to the user:
+
+```
+Snapshot (pandas):     <N>
+Target list (pandas):  <M>
+Real gap:              <M-N> URLs (<pct>%)
+Threshold (95%):       <0.95*M>
+
+Engine status: <fine | partial | not run>  (scan_date max = <date>)
+
+Missing URL breakdown:
+- Malformed index entries: <n>
+- Internal/VPN-gated:      <n>
+- Staging/UAT:             <n>
+- Genuinely unreachable:   <n>
+
+Conclusion: <smoke-test parser bug | real shortfall | engine outage>
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md
+
+Analysis scripts for the GSA Site Scanning program. Pulls public CSV snapshots from `api.gsa.gov` and writes summary reports back into the repo (which CI auto-commits).
+
+## Two sub-projects
+
+- **Root (Python 3.9, pandas-only):** report generators driven by `main.py`.
+- **`smoke_tests/` (Bun + TypeScript):** independent suite that validates the published snapshot data and files GitHub issues on failure. Has its own `package.json`, `README.md`, and CI workflow. Do not mix it with the Python code.
+
+## Run a report
+
+```sh
+pip install -r requirements.txt
+python3 main.py <command>
+```
+
+Valid commands live in the `valid_commands` dict in `main.py:127-145`. They are the source of truth — names are not all `generate-*` (e.g. `federal-standards-snapshot-report`, `website-requests-report`).
+
+Most commands fetch a remote CSV (URLs in `config.py`) so they need network access. There is no local data seeding step.
+
+`main.py:123` disables SSL verification globally (`ssl._create_default_https_context = ssl._create_unverified_context`). Leave it unless you have a reason; CI relies on it.
+
+## Tests
+
+```sh
+python3 -m unittest discover tests
+```
+
+Stdlib `unittest`, not pytest. Fixtures are committed CSVs next to the tests (`tests/test_*.csv`). CI (`.github/workflows/test.yml`) pins Python 3.9.
+
+Smoke tests are separate:
+
+```sh
+cd smoke_tests && bun install && bun run src/main.ts
+```
+
+`ISSUE_TOKEN` is required — without it the runner logs an error and exits before running any tests (it doesn't just skip issue creation). Register new smoke tests in `smoke_tests/src/services/tests/AllTests.ts`.
+
+## Report output paths are tracked artifacts
+
+CSV outputs in `reports/`, `snapshots/`, and `unique_website_list/results/` are committed back to `main` by the scheduled workflows in `.github/workflows/generate-*.yml` (via `git-auto-commit-action`). Treat them as generated but versioned — don't hand-edit, and expect noisy diffs after a local run.
+
+`reports/drafts/` and `reports/website-requests/` (with their own READMEs) are curated content, not pure outputs.
+
+## Adding a new report
+
+1. Add a generator class under `report_generators/` (mirror the existing pattern: take a `df` in `__init__`, expose `generate_report()`).
+2. Add the input URL and output path to `config.py`.
+3. Add a wrapper function in `main.py` and register it in `valid_commands`.
+4. Add the command to the relevant workflow under `.github/workflows/` if it should run on schedule.
+5. Add a `tests/test_*.py` with a small fixture CSV.
+
+## Architecture notes
+
+- `main.py` is a thin dispatcher: read remote CSV → instantiate generator → write CSV. Almost all logic lives in `report_generators/`.
+- The "snapshot" report (`Snapshot` class) is a question→answer dict serialized via `save_to_csv` with `['question', 'answer']` columns. Other generators (`Idea`, `Standards`, `Baseline`, etc.) return a DataFrame and write it directly. Don't conflate the two output shapes.
+- `unique_website_list/unique_website_list.py` is invoked via `main.py generate-unique-website-list` and produces the dedup'd CSVs that several downstream reports consume (`unique_final_websites_location`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Creating artifacts to diagnose when smoke tests record a threshold alert: https://github.com/GSA/site-scanning/issues/1920